### PR TITLE
OpenOrder: make sure to copy the updated contract

### DIFF
--- a/ib.go
+++ b/ib.go
@@ -958,7 +958,8 @@ func (ib *IB) PlaceOrder(contract *Contract, order *Order) *Trade {
 	if ok {
 		// modification of an existing order
 		if trade.IsDone() {
-			panic("try to modify a done trade")
+			log.Error().Int64("orderID", order.OrderID).Msg("try to modify a done trade")
+			return trade
 		}
 		logEntry := TradeLogEntry{
 			Time:    time.Now().UTC(),

--- a/wrapper.go
+++ b/wrapper.go
@@ -152,6 +152,7 @@ func (w *WrapperSync) OpenOrder(orderID OrderID, contract *Contract, order *Orde
 		trade.Order.OrderType = order.OrderType
 		trade.Order.OrderRef = order.OrderRef
 		trade.OrderStatus.Status = status
+		*trade.Contract = *contract
 		trade.mu.Unlock()
 	} else {
 		// Create a new trade if not found


### PR DESCRIPTION
- OpenOrder: make sure to copy the updated contract
  - related to https://github.com/scmhub/ibsync/issues/13
  - when requesting open orders the contract was not updated, so we could not see extra fields set by TWS

- also removed the panic from PlaceOrder as there can be a race condition:
  - client code checks the order status -> not done
  - order gets filled after the check
  - client code want to update the limit price -> panic

I believe we should not panic