### PR TITLE
fix: calling unlock in early returns

### DIFF
--- a/ib.go
+++ b/ib.go
@@ -341,6 +341,7 @@ func (ib *IB) ReqPnL(account string, modelCode string) {
 	ib.state.mu.Lock()
 	_, ok := ib.state.pnlKey2ReqID[key]
 	if ok {
+		ib.state.mu.Unlock()
 		log.Warn().Str("account", account).Str("modelCode", modelCode).Msg("Pnl request already made")
 		return
 	}
@@ -356,6 +357,7 @@ func (ib *IB) CancelPnL(account string, modelCode string) {
 	ib.state.mu.Lock()
 	reqID, ok := ib.state.pnlKey2ReqID[Key(account, modelCode)]
 	if !ok {
+		ib.state.mu.Unlock()
 		log.Warn().Str("account", account).Str("modelCode", modelCode).Msg("No pnl request to cancel")
 		return
 	}
@@ -422,6 +424,7 @@ func (ib *IB) ReqPnLSingle(account string, modelCode string, contractID int64) {
 	ib.state.mu.Lock()
 	_, ok := ib.state.pnlSingleKey2ReqID[key]
 	if ok {
+		ib.state.mu.Unlock()
 		log.Warn().Str("account", account).Str("modelCode", modelCode).Int64("contractID", contractID).Msg("Pnl single request already made")
 		return
 	}
@@ -436,6 +439,7 @@ func (ib *IB) CancelPnLSingle(account string, modelCode string, contractID int64
 	ib.state.mu.Lock()
 	reqID, ok := ib.state.pnlSingleKey2ReqID[Key(account, modelCode, contractID)]
 	if !ok {
+		ib.state.mu.Unlock()
 		log.Warn().Str("account", account).Str("modelCode", modelCode).Int64("contractID", contractID).Msg("No pnl single request to cancel")
 		return
 	}

--- a/wrapper.go
+++ b/wrapper.go
@@ -269,6 +269,7 @@ func (w *WrapperSync) ExecDetails(reqID int64, contract *Contract, execution *Ex
 	}
 	executionTime, err := ParseIBTime(execution.Time)
 	if err != nil {
+		w.state.mu.Unlock()
 		log.Error().Err(err).Int64("reqID", reqID).Msg("<ExecDetails>")
 		return
 	}
@@ -453,6 +454,7 @@ func (w *WrapperSync) CommissionAndFeesReport(commissionAndFeesReport Commission
 	w.state.mu.Lock()
 	fill, ok := w.state.fills[commissionAndFeesReport.ExecID]
 	if !ok {
+		w.state.mu.Unlock()
 		log.Error().Err(errUnknowExecution).Stringer("commissionReportAndFees", commissionAndFeesReport).Msg("<CommissionReportAndFeesœ		>")
 		return
 	}
@@ -693,6 +695,7 @@ func (w *WrapperSync) Pnl(reqID int64, dailyPnL float64, unrealizedPnL float64, 
 	w.state.mu.Lock()
 	pnl, ok := w.state.reqID2Pnl[reqID]
 	if !ok {
+		w.state.mu.Unlock()
 		log.Error().Err(errUnknowReqID).Msg("<Pnl>")
 		return
 	}
@@ -709,6 +712,7 @@ func (w *WrapperSync) PnlSingle(reqID int64, pos Decimal, dailyPnL float64, unre
 	w.state.mu.Lock()
 	pnlSingle, ok := w.state.reqID2PnlSingle[reqID]
 	if !ok {
+		w.state.mu.Unlock()
 		log.Error().Err(errUnknowReqID).Msg("<PnlSingle>")
 		return
 	}


### PR DESCRIPTION
there are cases that could cause deadlock when error happens.