### PR TITLE
CompletedOrder: use similar logic as in OrderStatus, store it using orderKey if available

### DIFF
--- a/trade.go
+++ b/trade.go
@@ -285,7 +285,10 @@ func (t *Trade) Equal(other *Trade) bool {
 }
 
 func (t *Trade) String() string {
-	t.mu.RLock()
+	if !t.mu.TryRLock() {
+		return "Trade{unknow(could not lock)}"
+	}
+
 	defer t.mu.RUnlock()
 
 	return fmt.Sprintf("Trade{Contract: %v, Order: %v, Status: %v, Fills: %v}",


### PR DESCRIPTION
completed order is stored by PermID, not orderKey even if it is available

plus I had issues with trade.String() being evaluated by the debugger and it caused deadlock