### PR TITLE
default execution filter: use current ClientID

### DIFF
--- a/ib.go
+++ b/ib.go
@@ -1315,6 +1315,7 @@ func (ib *IB) ReqExecutions(execFilter ...*ExecutionFilter) ([]Execution, error)
 	defer unsubscribe()
 
 	ef := ibapi.NewExecutionFilter()
+	ef.ClientID = ib.config.ClientID
 	if len(execFilter) > 0 {
 		ef = execFilter[0]
 	}
@@ -1367,6 +1368,7 @@ func (ib *IB) ReqFills(execFilter ...*ExecutionFilter) ([]Fill, error) {
 	defer unsubscribe()
 
 	ef := ibapi.NewExecutionFilter()
+	ef.ClientID = ib.config.ClientID
 	if len(execFilter) > 0 {
 		ef = execFilter[0]
 	}


### PR DESCRIPTION
follow up on: https://github.com/scmhub/ibapi/pull/13

when no filter is passed -> use current client id, otherwise client id = 0 is used by default and user is forced to always use the non-default filter.

when client id = 0 is used, it won't return all executions, only the ones placed by the client id 0.