### PR TITLE
OrderStatus: PendingCancel should also be considered active

### DIFF
--- a/trade.go
+++ b/trade.go
@@ -26,7 +26,7 @@ const (
 // IsActive returns true if the status indicates the order is still active in the market.
 func (s Status) IsActive() bool {
 	switch s {
-	case PendingSubmit, ApiPending, PreSubmitted, Submitted:
+	case PendingSubmit, ApiPending, PreSubmitted, Submitted, PendingCancel:
 		return true
 	default:
 		return false


### PR DESCRIPTION
OrderStatus: `PendingCancel` should also be considered active until it is `Cancelled` or `Filled`

Today during my testing in paper account I found an edge case:
- I cancelled the order
- waiting for trade to be done (via channel)
- once it is done, check if it was Filled
- if not Filled, the assumption was it was cancelled

but after reading the logs, the trade flipped from PendingCancel to Filled